### PR TITLE
Fix script newline escaping with expanded assets

### DIFF
--- a/lib/jquery-ui-rails-cdn.rb
+++ b/lib/jquery-ui-rails-cdn.rb
@@ -22,7 +22,7 @@ module Jquery::Ui::Rails::Cdn
       return javascript_include_tag(:'jquery.ui.all') if OFFLINE and !options[:force]
 
       [ javascript_include_tag(jquery_ui_url(name, options)),
-        javascript_tag("window.jQuery.ui || document.write(unescape('#{javascript_include_tag(:'jquery.ui.all').gsub('<','%3C')}'))")
+        javascript_tag("window.jQuery.ui || document.write(unescape('#{javascript_include_tag(:'jquery.ui.all').gsub('<','%3C').gsub("\n",'%0A')}'))")
       ].join("\n").html_safe
     end
   end


### PR DESCRIPTION
If `config.assets.debug = true` is set, the jquery.ui.all.js is expanded into several smaller required scripts. This means the javascript_include_tag returns newlines that need to be escaped to generate valid code.

Without this fix using force: true in development generates a parsing error. Chrome reports:

```
Uncaught SyntaxError: Unexpected token ILLEGAL
```

By urlencoding the newline character we can fix this.
