### PR TITLE
Use protocol relative url for code.jquery.com

### DIFF
--- a/lib/jquery-ui-rails-cdn.rb
+++ b/lib/jquery-ui-rails-cdn.rb
@@ -9,7 +9,7 @@ module Jquery::Ui::Rails::Cdn
     URL = {
       :google     => "//ajax.googleapis.com/ajax/libs/jqueryui/#{JQUERY_UI_VERSION}/jquery-ui.min.js",
       :microsoft  => "//ajax.aspnetcdn.com/ajax/jquery.ui/#{JQUERY_UI_VERSION}/jquery-ui.min.js",
-      :jquery     => "http://code.jquery.com/ui/#{JQUERY_UI_VERSION}/jquery-ui.min.js",
+      :jquery     => "//code.jquery.com/ui/#{JQUERY_UI_VERSION}/jquery-ui.min.js",
       :yandex     => "//yandex.st/jquery-ui/#{JQUERY_UI_VERSION}/jquery-ui.min.js",
       :cloudflare => "//cdnjs.cloudflare.com/ajax/libs/jqueryui/#{JQUERY_UI_VERSION}/jquery-ui.min.js"
     }


### PR DESCRIPTION
The jQuery CDN supports SSL, so we can use protocol relative URLs.

See: https://www.ssllabs.com/ssltest/analyze.html?d=code.jquery.com
