### PR TITLE
Only specify signing key if it exists

### DIFF
--- a/jquery-ui-rails-cdn.gemspec
+++ b/jquery-ui-rails-cdn.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |gem|
   gem.version       = Jquery::Ui::Rails::Cdn::VERSION
   gem.license       = 'MIT'
 
-  unless ENV['TRAVIS']
-    gem.signing_key = File.join(Dir.home, '/.gem/trust/gem-private_key.pem')
+  signing_key = File.join(Dir.home, '/.gem/trust/gem-private_key.pem')
+  if File.exist? signing_key
+    gem.signing_key = signing_key
     gem.cert_chain = ['gem-public_cert.pem']
   end
 


### PR DESCRIPTION
This gets rid of the following error when bundling from github:
Errno::ENOENT: No such file or directory @ rb_sysopen - $HOME/.gem/trust/gem-private_key.pem

This fix is required for bundle install to succeed when referencing the gem from git or local path.
