### PR TITLE
Always remove force from options hash

### DIFF
--- a/lib/jquery-ui-rails-cdn.rb
+++ b/lib/jquery-ui-rails-cdn.rb
@@ -19,10 +19,10 @@ module Jquery::Ui::Rails::Cdn
     end
 
     def jquery_ui_include_tag(name, options = {})
-      return javascript_include_tag(:'jquery.ui.all') if OFFLINE and !options[:force]
+      return javascript_include_tag('jquery.ui.all') if !options.delete(:force) and OFFLINE
 
       [ javascript_include_tag(jquery_ui_url(name, options)),
-        javascript_tag("window.jQuery.ui || document.write(unescape('#{javascript_include_tag(:'jquery.ui.all').gsub('<','%3C').gsub("\n",'%0A')}'))")
+        javascript_tag("window.jQuery.ui || document.write(unescape('#{javascript_include_tag('jquery.ui.all').gsub('<','%3C').gsub("\n",'%0A')}'))")
       ].join("\n").html_safe
     end
   end


### PR DESCRIPTION
This avoids force="true" on the script tags if force: true is set outside of OFFLINE environments.
